### PR TITLE
feat: updated schema definition and associations between models

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+class Event < ApplicationRecord
+  # Associations
+  belongs_to :creator, class_name: "User", inverse_of: :created_events
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,8 @@
+class Invitation < ApplicationRecord
+  has_secure_token :oauth_token, length: 36 # Rails built-in method (https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token)
+
+  # Associations
+  belongs_to :event
+  belongs_to :sender, class_name: "User", inverse_of: :sent_invitations
+  belongs_to :recipient, class_name: "User", inverse_of: :received_invitations
+end

--- a/app/models/invitee.rb
+++ b/app/models/invitee.rb
@@ -1,0 +1,5 @@
+class Invitee < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+  # Associations
+  has_many :events_as_creator, foreign_key: :creator_id, class_name: "Event", inverse_of: :creator, dependent: :destroy
+  has_many :invitees, dependent: :destroy
+  has_many :events, through: :invitees
+  has_many :invitations_as_sender, foreign_key: :sender_id, inverse_of: :sender, dependent: :destroy
+  has_many :invitations_as_recipient, foreign_key: :recipient_id, inverse_of: :recipient, dependent: :nullify
+end

--- a/db/migrate/20230805072151_create_users.rb
+++ b/db/migrate/20230805072151_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :uid, null: false
+      t.string :email, null: false
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230805072808_create_events.rb
+++ b/db/migrate/20230805072808_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events do |t|
+      t.string :title, null: false
+      t.text :description
+      t.datetime :date, null: false
+      t.integer :time, default: 60 # The duration of the event will default to 60 min according to specifications
+      t.references :creator, null: false, foreign_key: { to_table: :users}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230805072835_create_invitees.rb
+++ b/db/migrate/20230805072835_create_invitees.rb
@@ -1,0 +1,10 @@
+class CreateInvitees < ActiveRecord::Migration[7.0]
+  def change
+    create_table :invitees do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230805073029_create_invitations.rb
+++ b/db/migrate/20230805073029_create_invitations.rb
@@ -1,0 +1,16 @@
+class CreateInvitations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :invitations do |t|
+      t.string :url, null: false
+      t.boolean :accepted, default: false
+      t.boolean :expired, default: false
+      t.text :oauth_token, null: false
+      t.datetime :expiration_date, null: false
+      t.references :event, null: false, foreign_key: true
+      t.references :sender, null: false, foreign_key: { to_table: :users}
+      t.references :recipient, null: true, foreign_key: { to_table: :users} # If user is deleted, recipient can be null
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,59 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_05_073029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "events", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.datetime "date", null: false
+    t.integer "time", default: 60
+    t.bigint "creator_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_events_on_creator_id"
+  end
+
+  create_table "invitations", force: :cascade do |t|
+    t.string "url", null: false
+    t.boolean "accepted", default: false
+    t.boolean "expired", default: false
+    t.text "oauth_token", null: false
+    t.datetime "expiration_date", null: false
+    t.bigint "event_id", null: false
+    t.bigint "sender_id", null: false
+    t.bigint "recipient_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_invitations_on_event_id"
+    t.index ["recipient_id"], name: "index_invitations_on_recipient_id"
+    t.index ["sender_id"], name: "index_invitations_on_sender_id"
+  end
+
+  create_table "invitees", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_invitees_on_event_id"
+    t.index ["user_id"], name: "index_invitees_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "uid", null: false
+    t.string "email", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "events", "users", column: "creator_id"
+  add_foreign_key "invitations", "events"
+  add_foreign_key "invitations", "users", column: "recipient_id"
+  add_foreign_key "invitations", "users", column: "sender_id"
+  add_foreign_key "invitees", "events"
+  add_foreign_key "invitees", "users"
 end


### PR DESCRIPTION
## Changes Overview:
- Updated schema definition for the project
- Added associations between the models
- Ran migrations

**NOTE**:
- For invitations, the `time` field is defaulted to 60 as per specifications of the project. The data type is `integer` since we will be handling it in minutes.
- I supposed we wanted to use `omniauth` exclusively (there was no specification of user login in/signing up using password), so I have not given the user a password field. If needed, I would use the `Devise` gem for auth.

## Screenshots:
**Rubocop**
![Screen Shot 2023-08-05 at 17 54 07](https://github.com/josem-gp/event-manager/assets/69992326/d5663774-0d60-4dc7-aee2-02131c1712b5)

**Brakeman**
![Screen Shot 2023-08-05 at 17 54 15](https://github.com/josem-gp/event-manager/assets/69992326/7617d119-1c5e-4c72-b111-0a728a1495c4)
