### PR TITLE
feat: add logic for sending and accepting/rejecting invitations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ GMAIL_SMTP_PASSWORD=your_gmail_password
 
 # Your application name
 APP_NAME=your_app_name
+APP_URL=http://localhost:3000/
 
 # Redis server URL for caching
 REDIS_URL=redis://redis:6379

--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,9 @@ POSTGRES_PASSWORD=your_postgres_password
 # Rails environment
 RAILS_ENV=development
 
-# Gmail SMTP settings for sending emails
-GMAIL_SMTP_USER=your@gmail.com
-GMAIL_SMTP_PASSWORD=your_gmail_password
-
 # Your application name
 APP_NAME=your_app_name
-APP_URL=http://localhost:3000/
+APP_URL=http://localhost:3000
 
 # Redis server URL for caching
 REDIS_URL=redis://redis:6379

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development do
   # Static analysis security scanner for detecting vulnerabilities
   gem 'brakeman', require: false
 
-  # Preview email in the default browser instead of sending it
+  # Preview email in the default browser instead of sending it
   gem "letter_opener"
   # Gives letter_opener an interface for browsing sent emails
   gem 'letter_opener_web', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,11 @@ group :development do
   # Static analysis security scanner for detecting vulnerabilities
   gem 'brakeman', require: false
 
+  # Preview email in the default browser instead of sending it
+  gem "letter_opener"
+  # Gives letter_opener an interface for browsing sent emails
+  gem 'letter_opener_web', '~> 2.0'
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,15 @@ GEM
     json (2.6.3)
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -148,8 +157,6 @@ GEM
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.3-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -184,8 +191,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
-    rack-protection (3.0.6)
-      rack
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.6)
@@ -276,7 +283,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stimulus-rails (1.2.1)
+    stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     temple (0.10.2)
     thor (1.2.2)
@@ -311,7 +318,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap
@@ -322,6 +328,8 @@ DEPENDENCIES
   faker (~> 3.2)
   importmap-rails
   jbuilder
+  letter_opener
+  letter_opener_web (~> 2.0)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection (~> 1.0, >= 1.0.1)
   pg (~> 1.1)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,8 +2,8 @@ class EventsController < ApplicationController
   before_action :set_new_event, only: %i[new create]
   before_action :find_event_or_redirect, only: :show
 
-  def show 
-    @is_an_invitee = current_user.is_an_invitee?(@event)
+  def show
+    @is_an_invitee = current_user.an_invitee?(@event)
     @invitation = current_user.received_invitations.find_by(event: @event)
   end
 
@@ -25,9 +25,9 @@ class EventsController < ApplicationController
   end
 
   def find_event_or_redirect
-    unless @event = Event.find_by(id: params[:id])
-      redirect_to root_path, error: t('events.not_found')
-    end
+    return if (@event = Event.find_by(id: params[:id]))
+
+    redirect_to root_path, error: t('events.not_found')
   end
 
   def save_event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,12 @@
 class EventsController < ApplicationController
   before_action :set_new_event, only: %i[new create]
-  before_action :find_event, only: :show
+  before_action :find_event_or_redirect, only: :show
 
-  def show; end
+  def show 
+    @is_an_invitee = current_user.is_an_invitee?(@event)
+    @invitation = current_user.received_invitations.find_by(event: @event)
+  end
+
   def new; end
 
   def create
@@ -20,20 +24,23 @@ class EventsController < ApplicationController
     @event = Event.new
   end
 
-  def find_event
-    @event = Event.find(params[:id])
+  def find_event_or_redirect
+    unless @event = Event.find_by(id: params[:id])
+      redirect_to root_path, error: t('events.not_found')
+    end
   end
 
   def save_event
     @event.assign_attributes(event_params.except(:invitees_emails))
     @event.creator = current_user
 
-    if @event.save
-      @event.send_invitations(event_params[:invitees_emails])
-      true
-    else
-      false
-    end
+    return false unless @event.save
+
+    # After we save the event, we send the invitations if invitees exist
+    return true if event_params[:invitees_emails].blank?
+
+    InvitationService.new(@event, event_params[:invitees_emails]).call
+    true
   end
 
   def event_params

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,29 @@
+class InvitationsController < ApplicationController
+  before_action :find_invitation, only: %i[accept reject]
+  before_action :find_event, only: %i[accept reject]
+
+  def accept
+    invitee = Invitee.new(user: current_user, event: @event)
+    if invitee.save
+      @invitation.update(status: :accepted)
+      redirect_to event_path(@event), notice: 'Invitation accepted!'
+    else
+      redirect_to event_path(@event), notice: 'There was a problem accepting the invitation.'
+    end
+  end
+
+  def reject
+    @invitation.update(status: :denied)
+    redirect_to event_path(@event), notice: 'Invitation denied.'
+  end
+
+  private
+
+  def find_invitation
+    @invitation = Invitation.find(params[:id])
+  end
+
+  def find_event
+    @event = Event.find(params[:event_id])
+  end
+end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -6,15 +6,15 @@ class InvitationsController < ApplicationController
     invitee = Invitee.new(user: current_user, event: @event)
     if invitee.save
       @invitation.update(status: :accepted)
-      redirect_to event_path(@event), notice: 'Invitation accepted!'
+      redirect_to event_path(@event), notice: t('invitations.accepted')
     else
-      redirect_to event_path(@event), notice: 'There was a problem accepting the invitation.'
+      redirect_to event_path(@event), notice: t('invitations.error_when_accepting')
     end
   end
 
   def reject
     @invitation.update(status: :denied)
-    redirect_to event_path(@event), notice: 'Invitation denied.'
+    redirect_to event_path(@event), notice: t('invitations.denied')
   end
 
   private

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,23 @@
+module EventsHelper
+  # Date and Time Formatting
+  def formatted_event_date(date)
+    date.strftime('%B %e')
+  end
+
+  def event_weekday(date)
+    date.strftime('%A')
+  end
+
+  def event_time(time)
+    time.strftime('%I:%M %p')
+  end
+
+  # Name Formatting
+  def creator_full_name(creator)
+    "#{creator.first_name} #{creator.last_name}"
+  end
+
+  def invitee_full_name(invitee_user)
+    "#{invitee_user.first_name} #{invitee_user.last_name}"
+  end
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,0 +1,15 @@
+module InvitationsHelper
+  def show_invitees?
+    current_user_is_creator?(@event) || @is_an_invitee
+  end
+
+  def invitation_expired?
+    @invitation.expired
+  end
+
+  private
+
+  def current_user_is_creator?(event)
+    current_user == event.creator
+  end
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,10 +1,10 @@
 module InvitationsHelper
-  def show_invitees?
-    current_user_is_creator?(@event) || @is_an_invitee
+  def show_invitees?(event, is_an_invitee)
+    current_user_is_creator?(event) || is_an_invitee
   end
 
-  def invitation_expired?
-    @invitation.expired
+  def invitation_expired?(invitation)
+    invitation.expired
   end
 
   private

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,5 @@
 module UsersHelper
-  def is_invited?
-    current_user.received_invitations.not_expired.where(event: @event).any?
+  def invited?(event)
+    current_user.received_invitations.not_expired.where(event:).any?
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,5 @@
+module UsersHelper
+  def is_invited?
+    current_user.received_invitations.not_expired.where(event: @event).any?
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch('GMAIL_SMTP_USER', nil)
+  default from: "from@example.com"
   layout "mailer"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch('GMAIL_SMTP_USER', nil)
   layout "mailer"
 end

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -1,0 +1,9 @@
+class EventInvitationMailer < ApplicationMailer
+  def send_invitation
+    @recipient = params[:recipient]
+    @sender = params[:sender]
+    @url = params[:url]
+
+    mail(to: @recipient.email, subject: t('invitations.greetings'))
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,16 +9,6 @@ class Event < ApplicationRecord
   # We will only create events as per specification of the project
   after_validation :single_event_per_date_and_time, on: :create
 
-  def send_invitations(invitees_emails)
-    invitees_emails.split(",").each do |invitee|
-      # send invitation mailer (if user accepts, they become an Invitee)
-      EventInvitationMailer.with(recipient: invitee, sender: current_user,
-                                 url: invitation.url).send_invitation.deliver_later
-      # enqueue job to disable invitation after a day
-      DisableInvitationJob.set(wait: 1.day).perform_later(invitation:)
-    end
-  end
-
   private
 
   # Does not allow the creator to create another event during the same day and timeframe
@@ -29,7 +19,7 @@ class Event < ApplicationRecord
 
     existing_events = Event.where(
       creator:
-    ).where("date >= ? AND date <= ?", date, end_time)
+    ).where("(date, date + INTERVAL '60 MINUTE') OVERLAPS (?, ?)", date, end_time)
 
     errors.add(:base, "Another event already exists at this date and time") unless existing_events.empty?
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,9 +10,13 @@ class Event < ApplicationRecord
   after_validation :single_event_per_date_and_time, on: :create
 
   def send_invitations(invitees_emails)
-    # send invitation mailer (if user accepts, they become an Invitee)
-
-    # enqueue job to disable invitation after a day
+    invitees_emails.split(",").each do |invitee|
+      # send invitation mailer (if user accepts, they become an Invitee)
+      EventInvitationMailer.with(recipient: invitee, sender: current_user,
+                                 url: invitation.url).send_invitation.deliver_later
+      # enqueue job to disable invitation after a day
+      DisableInvitationJob.set(wait: 1.day).perform_later(invitation:)
+    end
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,8 +1,36 @@
 class Invitation < ApplicationRecord
-  has_secure_token :oauth_token, length: 36 # Rails built-in method (https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token)
+  enum status: { pending: 0, accepted: 1, denied: 2 }
 
   # Associations
   belongs_to :event
   belongs_to :sender, class_name: "User", inverse_of: :sent_invitations
   belongs_to :recipient, class_name: "User", inverse_of: :received_invitations
+
+  # Validations
+  validates :url, presence: true
+
+  # Callbacks
+  after_create :set_expiration_date
+
+  scope :not_expired, -> { where(expired: false) }
+  scope :expired, -> { where(expired: true) }
+
+  def pending?
+    status == 'pending'
+  end
+
+  def accepted?
+    status == 'accepted'
+  end
+
+  def denied?
+    status == 'denied'
+  end
+
+  private
+
+  def set_expiration_date
+    self.expiration_date = 1.day.from_now
+    save
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,8 @@ class User < ApplicationRecord
       user.email = auth.info.email
     end
   end
+
+  def is_an_invitee?(event)
+    Invitee.find_by(user: self, event: event).present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
     end
   end
 
-  def is_an_invitee?(event)
-    Invitee.find_by(user: self, event: event).present?
+  def an_invitee?(event)
+    Invitee.find_by(user: self, event:).present?
   end
 end

--- a/app/views/event_invitation_mailer/send_invitation.html.slim
+++ b/app/views/event_invitation_mailer/send_invitation.html.slim
@@ -1,0 +1,3 @@
+h1 You have been invited!
+p Please click the following link to check the event out
+= link_to "View Event", @url

--- a/app/views/event_invitation_mailer/send_invitation.text.erb
+++ b/app/views/event_invitation_mailer/send_invitation.text.erb
@@ -1,0 +1,4 @@
+You have been invited!
+
+Please click the following link to check the event out:
+<%= @url %>

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -4,8 +4,23 @@
       h2 = @event.title
     .card-body
       p.card-text = "Description: #{@event.description}"
-      p.card-text = "Day: #{@event.date.strftime('%B')} #{@event.date.day}, #{@event.date.strftime('%A')}"
-      p.card-text = "Time: #{@event.date.strftime('%I:%M %p')} to #{(@event.date + @event.time.minutes).strftime('%I:%M %p')}"
-      p.card-text = "Created by: #{@event.creator.first_name} #{@event.creator.last_name}"
-      - @event.invitees.each do |invitee|
-        p.card-text = "Invitee: #{invitee.user.first_name} #{invitee.user.last_name}"
+      p.card-text = "Day: #{formatted_event_date(@event.date)}, #{event_weekday(@event.date)}"
+      p.card-text = "Time: #{event_time(@event.date)} to #{event_time(@event.date + @event.time.minutes)}"
+      p.card-text = "Created by: #{creator_full_name(@event.creator)}"
+      - if show_invitees?
+        - if @event.invitees.count == 0
+          p.card-text = "There are no invitees"
+        - else
+          - @event.invitees.each do |invitee|
+            p.card-text = "Invitee: #{invitee_full_name(invitee.user)}"
+      - else
+        p.card-text = "Number of invitees: #{@event.invitees.count}"
+
+      -if is_invited? && !invitation_expired?
+        - if @invitation.pending?
+          = button_to 'Accept', accept_event_invitation_path(@event, @invitation), method: :patch, class: 'btn btn-primary'
+          = button_to 'Reject', reject_event_invitation_path(@event, @invitation), method: :patch, class: 'btn btn-danger'
+        - elsif @invitation.accepted?
+          p.card-text = "Invitation accepted"
+        - elsif @invitation.denied?
+          p.card-text = "Invitation denied"

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -7,7 +7,7 @@
       p.card-text = "Day: #{formatted_event_date(@event.date)}, #{event_weekday(@event.date)}"
       p.card-text = "Time: #{event_time(@event.date)} to #{event_time(@event.date + @event.time.minutes)}"
       p.card-text = "Created by: #{creator_full_name(@event.creator)}"
-      - if show_invitees?
+      - if show_invitees?(@event, @is_an_invitee)
         - if @event.invitees.count == 0
           p.card-text = "There are no invitees"
         - else
@@ -16,7 +16,7 @@
       - else
         p.card-text = "Number of invitees: #{@event.invitees.count}"
 
-      -if is_invited? && !invitation_expired?
+      -if invited?(@event) && !invitation_expired?(@invitation)
         - if @invitation.pending?
           = button_to 'Accept', accept_event_invitation_path(@event, @invitation), method: :patch, class: 'btn btn-primary'
           = button_to 'Reject', reject_event_invitation_path(@event, @invitation), method: :patch, class: 'btn btn-danger'

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -3,6 +3,7 @@ nav.navbar.bg-body-tertiary
     a.navbar-brand href=root_path Home
     ul.navbar-nav
       li.nav-item.d-flex.column-gap-2
+        = link_to "See Invitations (one of each)", letter_opener_web_path, class: "nav-link"
         - if current_user
           = link_to "Edit Profile", edit_user_path(current_user), class: "nav-link"
           = button_to "Logout", destroy_user_session_path, class: "nav-link", method: :delete

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,7 @@ module EventManager
     # /lib modules were not loaded automatically so I added this fix:
     # https://stackoverflow.com/questions/1073076/rails-lib-modules-and
     config.autoload_paths += %W(#{config.root}/lib)
+    # Configuration to enqueue jobs using Sidekiq
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,25 +59,12 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Configuration for the mailer
-  host = 'localhost:3000'
-  config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
-  config.action_mailer.delivery_method = :test #change to smtp in order to send emails
+
+  # Configuration for letter opener
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default :charset => "utf-8"
-
-
-  ActionMailer::Base.smtp_settings = {
-    :address => "smtp.gmail.com",
-    :port => 587,
-    :authentication => :plain,
-    :enable_starttls_auto => true,
-    :domain => "gmail.com",
-    :user_name => ENV['GMAIL_SMTP_USER'],
-    :password => ENV['GMAIL_SMTP_PASSWORD'] 
-  }
-
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,6 +59,25 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Configuration for the mailer
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
+  config.action_mailer.delivery_method = :test #change to smtp in order to send emails
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default :charset => "utf-8"
+
+
+  ActionMailer::Base.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :authentication => :plain,
+    :enable_starttls_auto => true,
+    :domain => "gmail.com",
+    :user_name => ENV['GMAIL_SMTP_USER'],
+    :password => ENV['GMAIL_SMTP_PASSWORD'] 
+  }
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,8 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['GMAIL_SMTP_USER']
+  config.mailer = 'MailForm::Base'
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
 
   # Configure the class responsible to send e-mails.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,8 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV['GMAIL_SMTP_USER']
-  config.mailer = 'MailForm::Base'
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
 
   # Configure the class responsible to send e-mails.

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV["REDIS_URL"] }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV["REDIS_URL"] }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,10 +34,13 @@ en:
     alphabetic_format: "only allows letters"
     successful_update: "Profile updated successfully."
   sessions:
-    logged_in: 'Logged in!'
-    logged_out: 'Logged out!'
+    logged_in: "Logged in!"
+    logged_out: "Logged out!"
   events:
     successful_creation: "Event created successfully."
     not_found: "Event not found"
   invitations:
     greetings: "You have been invited to an event!"
+    accepted: "Invitation accepted!"
+    denied: "Invitation denied."
+    error_when_accepting: "There was a problem accepting the invitation."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,5 +38,6 @@ en:
     logged_out: 'Logged out!'
   events:
     successful_creation: "Event created successfully."
+    not_found: "Event not found"
   invitations:
     greetings: "You have been invited to an event!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,5 @@ en:
     logged_out: 'Logged out!'
   events:
     successful_creation: "Event created successfully."
+  invitations:
+    greetings: "You have been invited to an event!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,19 @@ Rails.application.routes.draw do
 
   resources :home, only: :index
   resources :users, only: %i(edit update)
-  resources :events, only: %i(new create show)
+  resources :events, only: %i(new create show) do
+    resources :invitations, only: [] do
+      member do
+        patch :accept
+        patch :reject
+      end
+    end
+  end
+
   
   mount Sidekiq::Web => '/sidekiq'
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
+require 'sidekiq/web'
+# Configure Sidekiq-specific session middleware
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: "_interslice_session"
+
 Rails.application.routes.draw do
   root to: 'home#index'
   devise_for :users, controllers: {
@@ -9,4 +14,6 @@ Rails.application.routes.draw do
   resources :home, only: :index
   resources :users, only: %i(edit update)
   resources :events, only: %i(new create show)
+  
+  mount Sidekiq::Web => '/sidekiq'
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,11 @@
+:concurrency: 3
+:timeout: 60
+:verbose: true
+:queues:
+  # Queue priority:
+  # https://github.com/mperham/sidekiq/wiki/Advanced-Options
+  # https://mikerogers.io/2019/06/06/rails-6-sidekiq-queues
+  - default
+  - mailers
+  - active_storage_analysis
+  - active_storage_purge

--- a/db/migrate/20230806135723_remove_oauth_token_from_invitations.rb
+++ b/db/migrate/20230806135723_remove_oauth_token_from_invitations.rb
@@ -1,0 +1,5 @@
+class RemoveOauthTokenFromInvitations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :invitations, :oauth_token
+  end
+end

--- a/db/migrate/20230806135754_change_expiration_date_to_optional.rb
+++ b/db/migrate/20230806135754_change_expiration_date_to_optional.rb
@@ -1,0 +1,5 @@
+class ChangeExpirationDateToOptional < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :invitations, :expiration_date, true
+  end
+end

--- a/db/migrate/20230807143928_add_status_to_invitations.rb
+++ b/db/migrate/20230807143928_add_status_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddStatusToInvitations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invitations, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20230807144007_remove_accepted_from_invitations.rb
+++ b/db/migrate/20230807144007_remove_accepted_from_invitations.rb
@@ -1,0 +1,5 @@
+class RemoveAcceptedFromInvitations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :invitations, :accepted
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_06_022712) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_144007) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,15 +27,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_022712) do
 
   create_table "invitations", force: :cascade do |t|
     t.string "url", null: false
-    t.boolean "accepted", default: false
     t.boolean "expired", default: false
-    t.text "oauth_token", null: false
-    t.datetime "expiration_date", null: false
+    t.datetime "expiration_date"
     t.bigint "event_id", null: false
     t.bigint "sender_id", null: false
     t.bigint "recipient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["event_id"], name: "index_invitations_on_event_id"
     t.index ["recipient_id"], name: "index_invitations_on_recipient_id"
     t.index ["sender_id"], name: "index_invitations_on_sender_id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       GMAIL_SMTP_USER: ${GMAIL_SMTP_USER}
       GMAIL_SMTP_PASSWORD: ${GMAIL_SMTP_PASSWORD}
       APP_NAME: ${APP_NAME:-EventManager}
+      APP_URL: ${APP_URL:-http://localhost:3000/}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
@@ -49,6 +50,7 @@ services:
       GMAIL_SMTP_USER: ${GMAIL_SMTP_USER}
       GMAIL_SMTP_PASSWORD: ${GMAIL_SMTP_PASSWORD}
       APP_NAME: ${APP_NAME:-EventManager}
+      APP_URL: ${APP_URL:-http://localhost:3000/}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     environment:
       TZ: Asia/Tokyo
       RAILS_ENV: ${RAILS_ENV:-development}
-      GMAIL_SMTP_USER: ${GMAIL_SMTP_USER}
-      GMAIL_SMTP_PASSWORD: ${GMAIL_SMTP_PASSWORD}
       APP_NAME: ${APP_NAME:-EventManager}
       APP_URL: ${APP_URL:-http://localhost:3000/}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
@@ -47,8 +45,6 @@ services:
       - .:/myapp
     environment:
       RAILS_ENV: ${RAILS_ENV:-development}
-      GMAIL_SMTP_USER: ${GMAIL_SMTP_USER}
-      GMAIL_SMTP_PASSWORD: ${GMAIL_SMTP_PASSWORD}
       APP_NAME: ${APP_NAME:-EventManager}
       APP_URL: ${APP_URL:-http://localhost:3000/}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}

--- a/test/mailers/event_invitation_mailer_test.rb
+++ b/test/mailers/event_invitation_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventInvitationMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/event_invitation_mailer_preview.rb
+++ b/test/mailers/previews/event_invitation_mailer_preview.rb
@@ -1,0 +1,29 @@
+# Preview all emails at http://localhost:3000/rails/mailers/event_invitation_mailer
+require 'faker'
+
+class EventInvitationMailerPreview < ActionMailer::Preview
+  def send_invitation
+    recipient = User.new(
+      email: Faker::Omniauth.google[:info][:email],
+      first_name: Faker::Omniauth.google[:info][:first_name],
+      last_name: Faker::Omniauth.google[:info][:last_name],
+      password: '123456'
+    )
+    sender = User.new(
+      email: Faker::Omniauth.google[:info][:email],
+      first_name: Faker::Omniauth.google[:info][:first_name],
+      last_name: Faker::Omniauth.google[:info][:last_name],
+      password: '123456'
+    )
+    event = Event.new(
+      title: Faker::Lorem.sentence(word_count: rand(3..8)),
+      description: Faker::Lorem.paragraph,
+      date: ((Date.current - 10) + rand((Date.current + 30) - (Date.current - 10))),
+      time: 60,
+      creator: sender
+    )
+    invitation = Invitation.new(recipient: recipient, sender: sender, event: event, url: "#{ENV['APP_URL']}/events/135")
+
+    EventInvitationMailer.with(recipient: recipient, sender: sender, url: invitation.url).send_invitation
+  end
+end


### PR DESCRIPTION
## Changes Overview:
- Added invitation logic to be send as a mailer when we submit the event (if there are invitees)
- Created the invitation mail design and also preview
- Added the [letter_opener](https://github.com/ryanb/letter_opener) gem as per specifications of the project, and also accompanied it with `letter_opener_web` gem to be able to see the sent mail on the browser directly.
- Added Sidekiq config to run jobs in the background
- Created the accept/reject invitation logic
- Updated the event show page depending on the status of the user 
- Put some logic that the views use in helper methods.

NOTE:
- The specifications said only accept the invitation but I added the "reject" button as an extra to give more options to the actions the user can take.


## Screenshots:
**Rubocop**
![Screen Shot 2023-08-08 at 7 19 13](https://github.com/josem-gp/event-manager/assets/69992326/d1ade387-cb11-4c6b-a021-ab7edba552ee)

**Brakeman**
![Screen Shot 2023-08-08 at 7 19 00](https://github.com/josem-gp/event-manager/assets/69992326/285ed492-cc83-447d-bba0-1e3e3d7bedf1)