### PR TITLE
fix: remove unnecessary logging in crud actions

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,7 +14,6 @@ class EventsController < ApplicationController
       flash[:success] = t('events.successful_creation')
       redirect_to root_path
     else
-      handle_resource_error(@event, t('events.error_when_creating'))
       flash_errors(@event)
       render :new, status: :unprocessable_entity, content_type: 'text/html'
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,6 @@ class UsersController < ApplicationController
       flash[:success] = t('users.successful_update')
       redirect_to root_path
     else
-      handle_resource_error(current_user, t('users.error_when_updating'))
       flash_errors(current_user)
       render :edit, status: :unprocessable_entity, content_type: "text/html"
     end


### PR DESCRIPTION
## Changes Overview:
- Remove unnecessary logging in CRUD actions. We already give the user feedback via flashes so no need to clog the logs.

## Screenshots:
**Rubocop**
![Screen Shot 2023-08-09 at 11 43 01](https://github.com/josem-gp/event-manager/assets/69992326/bbf375aa-86fa-4da5-ba49-0af82ead1f20)

**Brakeman**
![Screen Shot 2023-08-09 at 11 43 10](https://github.com/josem-gp/event-manager/assets/69992326/a7f3e856-99c3-4d03-bcb6-97f9b1570372)
