### PR TITLE
feat: unit test job and mailer

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # To adjust the log level
-  config.log_level = :info
+  config.log_level = :warn
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/spec/jobs/disable_invitation_job_spec.rb
+++ b/spec/jobs/disable_invitation_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe DisableInvitationJob, type: :job do
+  let(:invitation) { create :invitation }
+
+  it 'disables the invitation' do
+    expect(invitation).not_to be_expired
+
+    described_class.perform_now(invitation)
+
+    invitation.reload
+    expect(invitation).to be_expired
+  end
+end

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -1,0 +1,24 @@
+# spec/mailers/event_invitation_mailer_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe EventInvitationMailer, type: :mailer do
+  describe '#send_invitation' do
+    let(:recipient) { create(:user, email: 'recipient@example.com') }
+    let(:sender) { create(:user, email: 'sender@example.com') }
+    let(:url) { 'https://example.com/events/135' }
+
+    let(:mail) { EventInvitationMailer.with(recipient: recipient, sender: sender, url: url).send_invitation }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq(I18n.t('invitations.greetings'))
+      expect(mail.to).to eq(['recipient@example.com'])
+      expect(mail.from).to eq(['from@example.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('You have been invited!')
+      expect(mail.body.encoded).to match('https://example.com/events/135')
+    end
+  end
+end

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EventInvitationMailer, type: :mailer do
     let(:sender) { create(:user, email: 'sender@example.com') }
     let(:url) { 'https://example.com/events/135' }
 
-    let(:mail) { EventInvitationMailer.with(recipient: recipient, sender: sender, url: url).send_invitation }
+    let(:mail) { EventInvitationMailer.with(recipient:, sender:, url:).send_invitation }
 
     it 'renders the headers' do
       expect(mail.subject).to eq(I18n.t('invitations.greetings'))


### PR DESCRIPTION
## Changes Overview:
- Created unit tests for disable invitation `job` and invitation `mailer`
- Changed logging config so it outputs only from `warn` and above

## Screenshots:
**RSpec**
![Screen Shot 2023-08-11 at 11 45 59](https://github.com/josem-gp/event-manager/assets/69992326/148dcf5f-9625-4af7-99f0-92f2b1bd2fc2)

**Rubocop**
![Screen Shot 2023-08-11 at 11 45 28](https://github.com/josem-gp/event-manager/assets/69992326/96bf1453-4bd9-4eb7-8c57-f97615732a08)

NOTE: I won't be adding screenshots of Brakeman unless I make changes on the logic of the app