### PR TITLE
feat: created feature specs for sign up and login with Devise/Omniauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   # Used to easily generate fake data
   gem 'faker', '~> 3.2'
+  # Gives letter_opener an interface for browsing sent emails
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 group :development do
@@ -82,8 +84,6 @@ group :development do
 
   # Preview email in the default browser instead of sending it
   gem "letter_opener"
-  # Gives letter_opener an interface for browsing sent emails
-  gem 'letter_opener_web', '~> 2.0'
 
   # Rspec command for spring
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.3-aarch64-linux)
+    nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,5 @@ Rails.application.routes.draw do
 
   
   mount Sidekiq::Web => '/sidekiq'
-
-  if Rails.env.development?
-    mount LetterOpenerWeb::Engine, at: "/letter_opener"
-  end
+  mount LetterOpenerWeb::Engine, at: "/letter_opener"
 end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -4,12 +4,8 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   describe '#google_oauth2' do
     context 'when user is successfully authenticated' do
       before do
-        request.env['devise.mapping'] = Devise.mappings[:user]
-        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
-
         allow(controller).to receive(:sign_out_all_scopes)
-
-        get :google_oauth2
+        setup_mock_omniauth_valid_credentials
       end
 
       it 'signs out all scopes' do
@@ -28,11 +24,11 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
     context 'when user authentication fails' do
       before do
-        OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
-        request.env['devise.mapping'] = Devise.mappings[:user]
-        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+        setup_mock_omniauth_invalid_credentials
+      end
 
-        get :google_oauth2
+      after do
+        reset_mock_omniauth
       end
 
       it 'sets a flash error' do

--- a/spec/features/authentication/devise_login_spec.rb
+++ b/spec/features/authentication/devise_login_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Log in with Devise', type: :feature do
+  let(:user) { create(:user) }
+
+  scenario 'User can log in successfully using Devise' do
+    visit new_user_session_path
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_content("Signed in successfully.")
+  end
+
+  scenario "User logs in unsuccesfully using Devise" do
+    visit new_user_session_path
+
+    fill_in "Password", with: user.password
+    click_button "Log in"
+
+    expect(page).to have_text('Invalid Email or password')
+  end
+end

--- a/spec/features/authentication/devise_signup_spec.rb
+++ b/spec/features/authentication/devise_signup_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Sign up with Devise', type: :feature do
+  scenario 'User can sign up successfully using Devise' do
+    visit new_user_registration_path
+
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Email", with: "john@example.com"
+    fill_in "Password", with: "password"
+    fill_in "Password confirmation", with: "password"
+    click_button "Sign up"
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_content("Welcome John Doe")
+  end
+
+  scenario 'User signs up unsuccesfully using Devise' do
+    visit new_user_registration_path
+
+    click_button "Sign up"
+
+    expect(page).to have_current_path(user_registration_path)
+    expect(page).to have_content("can't be blank")
+  end
+end

--- a/spec/features/authentication/omniauth_signin_spec.rb
+++ b/spec/features/authentication/omniauth_signin_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Sign in with OmniAuth', type: :feature do
+  scenario 'User can sign in using OmniAuth' do
+    visit new_user_session_path
+
+    within('.d-flex.justify-content-center') do
+      click_button('Login with Google Omniauth')
+    end
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_content("Successfully authenticated from Google account.")
+  end
+
+  scenario 'User signs in unsuccesfully using OmniAuth' do
+    OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+
+    visit new_user_session_path
+
+    within('.d-flex.justify-content-center') do
+      click_button('Login with Google Omniauth')
+    end
+
+    expect(page).to have_content("Could not authenticate you from GoogleOauth2")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include OmniauthHelpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -1,0 +1,18 @@
+module OmniauthHelpers
+  def setup_mock_omniauth_valid_credentials
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+    get :google_oauth2
+  end
+
+  def setup_mock_omniauth_invalid_credentials
+    OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+    get :google_oauth2
+  end
+
+  def reset_mock_omniauth
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(Faker::Omniauth.google)
+  end
+end


### PR DESCRIPTION
## Changes Overview:
- Added feature tests for `omniauth` and `devise` signup and login logic.
- Updated the `routes` and `Gemfile` since I was mounting `letter-opener` only for development and it was giving an error when testing
- Refactored the `omniauth` auth logic into a helper

## Screenshots:
**RSpec**
![Screen Shot 2023-08-12 at 6 15 01](https://github.com/josem-gp/event-manager/assets/69992326/d070cfa2-4a90-45ee-a116-8411e3261b18)

**Rubocop**
![Screen Shot 2023-08-12 at 6 14 47](https://github.com/josem-gp/event-manager/assets/69992326/1e88b9b7-eee0-4fb3-9b64-ad30a24a84f8)

NOTE: I won't be adding screenshots of Brakeman unless I make changes on the logic of the app